### PR TITLE
🚨  Added master branch check

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,7 +208,17 @@ module.exports = function(gulp, swig) {
         process.exit(1);
       }
       swig.log.info('Since you are releasing from a branch that is not "master"');
-      swig.log.info('The version you will choose will be suffixed with "-rc"');
+      swig.log.info('the version you will choose will be suffixed with "-rc",');
+      swig.log.info('and you will only be allowed to release on staging.');
+      swig.log('');
+      if (!novayml.environments.find(e => e.stacks.find(
+            s => s.stack_name.toLowerCase() === 'staging'))) {
+        swig.log.info('It seems like you do not have a staging stack set in your nova.yml');
+        swig.log.info('Aborting the operation.'.red);
+        process.exit(1);
+      } else {
+        argConfig.stack = 'staging';
+      }
     }
 
     if (!argConfig.env) {
@@ -247,6 +257,10 @@ module.exports = function(gulp, swig) {
           s => s.stack_name.toLowerCase() === argConfig.stack.toLowerCase());
       if (!stackConf) {
         swig.log.error(`Stack '${argConfig.stack}' for environment ${env} not found in your nova.yml.`);
+        if (isNotMasterBranch) {
+          swig.log.info('Aborted!'.red);
+          process.exit(1);
+        }
       } else {
         argConfig.stack = stack = stackConf.stack_name;
       }
@@ -450,7 +464,7 @@ module.exports = function(gulp, swig) {
   });
 
   gulp.task('nova-version-cleanup', function() {
-    swig.log.info('');
+    swig.log('');
     if (isNewBuild) {
       let gitCommands;
       if (isNotMasterBranch) {
@@ -476,7 +490,7 @@ module.exports = function(gulp, swig) {
   });
 
   gulp.task('nova-build-docker', function() {
-    swig.log.info('');
+    swig.log('');
     swig.log.info('Building Docker image');
     const imageAlreadyExists = execSync('docker images -q ' + novayml.service_name + ':' + deployVersion, execSyncOpts.returnOutput);
     const homeNpmrcPath = path.join(process.env.HOME, '.npmrc');

--- a/index.js
+++ b/index.js
@@ -176,9 +176,25 @@ module.exports = function(gulp, swig) {
     const prompt = inquirer.createPromptModule();
     const environments = novayml.environments.map(e => e.name);
     const v = getLatestVersionTag().replace('v', '').split('.').map(n => +n);
+    const curBranch = execSync('git rev-parse --abbrev-ref HEAD',
+        execSyncOpts.returnOutput);
 
     let answer;
     let env;
+
+    if (curBranch !== 'master') {
+      swig.log('');
+      answer = yield prompt({
+        type: 'confirm',
+        name: 'confirmed',
+        message: 'WARNING: You are about to release from a branch different than "master". Are you sure you want to continue?',
+        default: false
+      });
+      if (!answer.confirmed) {
+        swig.log.info('Aborted!'.red);
+        process.exit(1);
+      }
+    }
 
     if (!argConfig.env) {
       if (environments.length > 1) {

--- a/index.js
+++ b/index.js
@@ -448,15 +448,18 @@ module.exports = function(gulp, swig) {
   });
 
   gulp.task('nova-version-cleanup', function() {
+    swig.log.info('');
     if (isNewBuild) {
       let gitCommands;
       if (isNotMasterBranch) {
+        swig.log.info('Tagging RC version on git');
         gitCommands = [
           'git tag -a -m "Release Candidate v' + deployVersion + '" v' + deployVersion,
           'git push --tags',
           'git checkout package.json'
         ];
       } else {
+        swig.log.info('Tagging release version on git');
         gitCommands = [
           'git add package.json',
           'git tag -a -m "v' + deployVersion + '" v' + deployVersion,
@@ -471,6 +474,8 @@ module.exports = function(gulp, swig) {
   });
 
   gulp.task('nova-build-docker', function() {
+    swig.log.info('');
+    swig.log.info('Building Docker image');
     const imageAlreadyExists = execSync('docker images -q ' + novayml.service_name + ':' + deployVersion, execSyncOpts.returnOutput);
     const homeNpmrcPath = path.join(process.env.HOME, '.npmrc');
     const localNpmrcPath = path.join('.','.npmrc');
@@ -534,8 +539,8 @@ module.exports = function(gulp, swig) {
       'nova-new-version',
       'nova-specified-version',
       'assets-deploy',
-      'nova-version-cleanup',
       'nova-build-docker',
+      'nova-version-cleanup',
       'nova-call-deploy',
       done);
   });

--- a/index.js
+++ b/index.js
@@ -23,25 +23,27 @@ module.exports = function(gulp, swig) {
   const semverDiff = require('semver-diff');
   const YAML = require('yamljs');
   const path = require('path');
+
   const execSyncOpts = {
-      returnOutput: {
-        encoding: 'utf8'
-      },
-      pipeOutput: {
-        encoding: 'utf8',
-        stdio: 'inherit'
-      }
-    };
+    returnOutput: {
+      encoding: 'utf8'
+    },
+    pipeOutput: {
+      encoding: 'utf8',
+      stdio: 'inherit'
+    }
+  };
+
   const argConfig = {
-      env: null,
-      stack: null,
-      newVersion: null,
-      version: null,
-      forcedRun: false
-    };
+    env: null,
+    stack: null,
+    newVersion: null,
+    version: null,
+    forcedRun: false
+  };
 
   const isNotMasterBranch = execSync('git rev-parse --abbrev-ref HEAD',
-        execSyncOpts.returnOutput) !== 'master';
+        execSyncOpts.returnOutput).trim() !== 'master';
 
   const lastRc = execSync(`git tag -l --sort=-v:refname | egrep '(?:\-rc\\d+)$' | head -n 1`, execSyncOpts.returnOutput);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gilt-tech/swig-nova",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "gilt-swig module for deploying with nova deployment tool",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* **Added check on current branch.**
   If the user tries to release from a branch other than `master`
   the tool will prompt for a confirmation to continue, defaulted to No

* **Added git tag differentiation for release candidates.**
   If a release is made from a branch other than `master` we will
   treat it as a Release Candidate and will suffix the version
   number with an `-rc` identifier.

Note: Should not be abused! It's more a fail safe check, rather than a
new workflow.